### PR TITLE
GH-4 Implement Auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.585.0",
         "@aws-sdk/lib-dynamodb": "^3.585.0",
-        "dotenv": "^16.4.5",
         "serverless-http": "^3.2.0"
       },
       "devDependencies": {
+        "dotenv": "^16.4.5",
         "jest": "^29.7.0",
         "nodemon": "^3.1.4",
         "serverless-offline": "^13.6.0"
@@ -6306,6 +6306,8 @@
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
       "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.585.0",
     "@aws-sdk/lib-dynamodb": "^3.585.0",
-    "dotenv": "^16.4.5",
     "serverless-http": "^3.2.0"
   },
   "devDependencies": {
+    "dotenv": "^16.4.5",
     "jest": "^29.7.0",
     "nodemon": "^3.1.4",
     "serverless-offline": "^13.6.0"

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,6 +14,14 @@ provider:
     DB_TABLE_NAME: ${self:custom.reviewsTableName}
   tags:
     env: ${self:provider.stage}
+  httpApi:
+    name: ${self:provider.stage}-${self:service}
+    authorizers:
+      auth0Authorizer:
+        identitySource: "$request.header.Authorization"
+        issuerUrl: ${env:AUTH0_DOMAIN}
+        audience: 
+        - ${env:AUTH0_AUDIENCE}
 
 # define custom variables here
 custom:
@@ -24,8 +32,10 @@ functions:
     handler: internal/handlers/hello.handleGetHello
     events:
       - httpApi:
-          path: /hello
           method: get
+          path: /hello
+          authorizer:
+            name: auth0Authorizer
     # iamRoleStatements:
     #   - Effect: "Allow"
     #     Action:


### PR DESCRIPTION
I created an API in auth0 and was able to successfully integrate it. A couple things of note:
- You will see I am using the dotenv package to manage environment variables. Whoever wants to deploy this serverless application will need to get these environment variables from me (or log into the auth0 console to get them)
- This is currently just a blanket auth on the dummy hello route. It does not check for an `auburn.edu` email address, as this will come later on the client side.
- I tested this by deploying to dev, ensuring the route returned a 403, then a 200 with a proper jwt token